### PR TITLE
Don't flag \(C|c)refname

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
 - id: cleveref-capitalization
   name: Ensure the correct usage of \cref
   description: Ensure that \Cref at a sentence start is capitalized and nowhere else in the sentence.
-  entry: "^((\\s*\\\\cref)|[^%\\s]+\\\\Cref).*$"
+  entry: "^((\\s*\\\\cref(?!name))|[^%\\s]+\\\\Cref(?!name)).*$"
   language: pygrep
   types: [file, tex]
   minimum_pre_commit_version: "2.8.0"


### PR DESCRIPTION
Thanks for the pre-commit hooks for latex!

I found what appears to be minor bug. \Crefname and \crefname are used to define clever ref styles, not generate text.
They shouldn't be flagged as being the middle or beginning of a sentence.