### PR TITLE
Alternative fix for #19

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,13 @@
 - id: cleveref-capitalization
   name: Ensure the correct usage of \cref
   description: Ensure that \Cref at a sentence start is capitalized and nowhere else in the sentence.
-  entry: "^((\\s*\\\\cref)|[^%\\s]+\\\\Cref).*$"
+  entry: |
+    (?x)
+    ^(
+      (?:\s*\\(?:cref|crefrange|cpageref|cpagerefrange|namecref|namecrefs)\b)
+      |
+      (?:[^%\\s]+\\(?:Cref|Crefrange|Cpageref|Cpagerefrange|nameCref|nameCrefs)\b)
+    ).*$
   language: pygrep
   types: [file, tex]
   minimum_pre_commit_version: "2.8.0"

--- a/tests/cleveref-capitalization.tex
+++ b/tests/cleveref-capitalization.tex
@@ -1,0 +1,64 @@
+\documentclass[11pt]{article}
+\usepackage{hyperref}
+\usepackage{cleveref}
+
+% These should NOT trigger warnings
+\crefname{section}{Sect.}{Sect.}
+\Crefname{section}{Section}{Sections}
+
+% These should NOT trigger warning
+\crefformat{page}{LOWERCASE #1 #2 #3}
+\Crefformat{page}{UPPERCASE #1 #2 #3}
+
+\begin{document}
+
+\section{A}
+\label{sa}
+
+\subsection{a}
+\label{ssaa}
+
+\subsection{b}
+\label{ssab}
+
+\section{B}
+\label{sb}
+
+\subsection{a}
+\label{ssba}
+
+\section{C}
+\label{sc}
+
+% These should all trigger warnings
+cref
+\cref{sa}
+abc \Cref{sa}
+
+crefrange
+\crefrange {sa} {sc}
+abc \Crefrange {sa} {sc}
+
+cpageref
+\cpageref{sa}
+abc \Cpageref{sa}
+
+cpagerefrange
+\cpagerefrange {sa} {sc}
+abc \Cpagerefrange{sa} {sc}
+
+namecref
+\namecref{sa}
+abc \nameCref{sa}
+
+namecrefs
+\namecrefs{sa}
+abc \nameCrefs{sa}
+
+% These should NOT trigger warning
+% There is no uppercase version
+labelcref
+\labelcref {sa,sc}
+\labelcpageref{sa,sc}
+
+\end{document}


### PR DESCRIPTION
This is an alternative fix for #19.
There are more cleveref commands starting with `\cref` where
capitalization should not matter besides `crefname`, for example
`crefformat`.
The regex is now updated to only include the commands which matter and
is terminated by a `\b` to prevent partial matches. The list of commands
is taken from the cleveref documentation.

http://tug.ctan.org/tex-archive/macros/latex/contrib/cleveref/cleveref.pdf

This shows the hook output on the new test file:

```bash
$ pre-commit try-repo . cleveref-capitalization --files ./tests/cleveref-capitalization.tex
[WARNING] Creating temporary repo with uncommitted changes...
===============================================================================
Using config:
===============================================================================
repos:
-   repo: /tmp/tmpbvxbwz3j/shadow-repo
    rev: 904ac72c830d1fe7bb72e6c80d2a005df8fc4e26
    hooks:
    -   id: cleveref-capitalization
===============================================================================
[INFO] Initializing environment for /tmp/tmpbvxbwz3j/shadow-repo.
Ensure the correct usage of \cref........................................Failed
- hook id: cleveref-capitalization
- exit code: 1

tests/cleveref-capitalization.tex:35:\cref{sa}
tests/cleveref-capitalization.tex:36:abc \Cref{sa}
tests/cleveref-capitalization.tex:39:\crefrange {sa} {sc}
tests/cleveref-capitalization.tex:40:abc \Crefrange {sa} {sc}
tests/cleveref-capitalization.tex:43:\cpageref{sa}
tests/cleveref-capitalization.tex:44:abc \Cpageref{sa}
tests/cleveref-capitalization.tex:47:\cpagerefrange {sa} {sc}
tests/cleveref-capitalization.tex:48:abc \Cpagerefrange{sa} {sc}
tests/cleveref-capitalization.tex:51:\namecref{sa}
tests/cleveref-capitalization.tex:52:abc \nameCref{sa}
tests/cleveref-capitalization.tex:55:\namecrefs{sa}
tests/cleveref-capitalization.tex:56:abc \nameCrefs{sa}
```