### PR TITLE
Fix cleveref-capitalization

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,9 +11,17 @@
   entry: |
     (?x)
     ^(
-      (?:\s*\\(?:cref|crefrange|cpageref|cpagerefrange|namecref|namecrefs)\b)
+      (?# Consume leading whitespace )
+      \s*
+
+      (?# Warn if a lowercase command is used at the beginning of a line, modulo whitespace )
+      \\(?:cref|crefrange|cpageref|cpagerefrange|namecref|namecrefs)\b
       |
-      (?:[^%\\s]+\\(?:Cref|Crefrange|Cpageref|Cpagerefrange|nameCref|nameCrefs)\b)
+      (?:
+        (?# Do not match if the cref is part of a comment )
+        [^%\s][^%]*
+        \\(?:Cref|Crefrange|Cpageref|Cpagerefrange|nameCref|nameCrefs)\b
+      )
     ).*$
   language: pygrep
   types: [file, tex]
@@ -55,7 +63,7 @@
   minimum_pre_commit_version: "2.8.0"
 - id: cispa-syssec-forbidden-words
   name: Forbidden words for CISPA SysSec
-  entry: '(?i)blacklist|whitelist'
+  entry: "(?i)blacklist|whitelist"
   language: pygrep
   types: [file, tex]
   minimum_pre_commit_version: "2.8.0"

--- a/tests/cleveref-capitalization.tex
+++ b/tests/cleveref-capitalization.tex
@@ -33,7 +33,9 @@
 % These should all trigger warnings
 cref
 \cref{sa}
-abc \Cref{sa}
+    \cref{sa}
+abc def \Cref{sa}
+Some sentence here (see~\Cref{sa}).
 
 crefrange
 \crefrange {sa} {sc}
@@ -57,6 +59,15 @@ abc \nameCrefs{sa}
 
 % These should NOT trigger warning
 % There is no uppercase version
+cref
+Foo \cref{sa} bar.
+\Cref{sa}
+    \Cref{sa}
+cref % \Cref{sa}
+cref % \cref{sa}
+%\Cref{sa}
+%\cref{sa}
+
 labelcref
 \labelcref {sa,sc}
 \labelcpageref{sa,sc}


### PR DESCRIPTION
This part of the old regex is wrong: [^%\\s]
It matches a literal %, literal \  or literal s instead of all
whitespace characters.

Add some more tests to ensure the regex works properly.