### PR TITLE
Only complain if `\cite` is preceded by white space or `{`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -63,7 +63,7 @@
 - id: tilde-cite
   name: Each \cite needs a ~
   description: Line breaks should never occur before the citation, thus they need to be protected with the ~.
-  entry: "[^~]\\\\cite\\b"
+  entry: "[\s\}]\\\\cite\\b"
   language: pygrep
   types: [file, tex]
   minimum_pre_commit_version: "2.8.0"


### PR DESCRIPTION
`\cite` may be given as a parameter to a command, so it is not always the case that the character immediately before `\cite` should be a `~`. Closes #106