### PR TITLE
Add option to ignore the content of labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ repos:
       - id: no-space-in-cite
       - id: tilde-cite
       - id: unique-labels
+        # args:
+        #     [
+        #       # If present only check that there is a \label{} but not the value
+        #       "--ignore-label-content",
+        #     ]
       - id: cleveref-instead-of-autoref
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0

--- a/src/bin/ensure-labels.rs
+++ b/src/bin/ensure-labels.rs
@@ -194,23 +194,22 @@ fn process_file(file: &Path, ignore_label_content: bool) -> Result<FileStatus, E
                     );
                 }
                 Some(label) => {
-                    let skip_check = capture
-                        .comment
-                        .map(|cmt| cmt.contains("skip-label"))
-                        .unwrap_or(false);
-                    // if ignore_label_content  && label != slug &&
-                    if !skip_check && label != slug {
-                        if !ignore_label_content {
-                            let line_number = offset_to_line_number(&text, capture.offset);
-                            found_mismatch = true;
-                            println!(
-                                "{}:{} Wrong Label '{}', use \\label{{{}}}",
-                                file.display(),
-                                line_number,
-                                label,
-                                slug
-                            );
-                        }
+                    if label != slug
+                        && !ignore_label_content
+                        && !capture
+                            .comment
+                            .map(|cmt| cmt.contains("skip-label"))
+                            .unwrap_or(false)
+                    {
+                        let line_number = offset_to_line_number(&text, capture.offset);
+                        found_mismatch = true;
+                        println!(
+                            "{}:{} Wrong Label '{}', use \\label{{{}}}",
+                            file.display(),
+                            line_number,
+                            label,
+                            slug
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Hi! Love the tools in this repository.

This is a small addition to one of them, the `ensure_labels` one. As it is now, it enforces a particular style of labels for a section which isn't personally what I use. So I've added an option, `-i` or `--ignore-label-content` which makes the tool only cause an error if there is no label at all after the sectioning command, rather than causing an error if the label doesn't fit your style.

I haven't added tests or documentation because neither were really already there, but I can easily do so if you'd like, depending on how you'd like the tests to be done.

Thanks!